### PR TITLE
Change app to client

### DIFF
--- a/app/__main__.py
+++ b/app/__main__.py
@@ -16,7 +16,7 @@ client = Client("my_account", api_id, api_id_hash)
 app = TranslationApp(client, chat_to_translate='me') # Replace 'me' with -1001173826177 for real HK channel
 
 app.add_consumers(
-    # TelegramConsumer(app, -324271754), # HK Translation Chat
+    # TelegramConsumer(client, -324271754), # HK Translation Chat
     TelegramConsumer(client, 'me'), # self, for testing
 )
 


### PR DESCRIPTION
This fixes the error we were seeing before:

```
pyrogram.errors.exceptions.bad_request_400.ChannelInvalid: [400 CHANNEL_INVALID]: The channel parameter is invalid (caused by "channels.GetMessages")
```